### PR TITLE
Default foreground_colour

### DIFF
--- a/gunicorn_console.py
+++ b/gunicorn_console.py
@@ -20,7 +20,7 @@ up/down changes selection
 """
 no_gunicorns = "Aww, no gunicorns are running!!"
 screen_width = None
-foreground_colour = curses.COLOR_BLACK
+foreground_colour = curses.COLOR_GREEN
 background_colour = curses.COLOR_BLUE
 
 


### PR DESCRIPTION
Hi ! 

I think the foreground_colour of that beautiful console must be green.
- Much more readable (on terminal Osx at least)
- Green Unicorn Console must be green

Thank you.
