### PR TITLE
Default background_colour

### DIFF
--- a/gunicorn_console.py
+++ b/gunicorn_console.py
@@ -20,8 +20,8 @@ up/down changes selection
 """
 no_gunicorns = "Aww, no gunicorns are running!!"
 screen_width = None
-foreground_colour = curses.COLOR_GREEN
-background_colour = curses.COLOR_BLUE
+foreground_colour = curses.COLOR_BLACK
+background_colour = curses.COLOR_GREEN
 
 
 if platform == "darwin":

--- a/gunicorn_console.py
+++ b/gunicorn_console.py
@@ -20,7 +20,7 @@ up/down changes selection
 """
 no_gunicorns = "Aww, no gunicorns are running!!"
 screen_width = None
-foreground_colour = curses.COLOR_BLACK
+foreground_colour = curses.COLOR_GREEN
 background_colour = curses.COLOR_BLUE
 
 


### PR DESCRIPTION
Hi !

I think the background_colour of that beautiful console must be green.

Much more readable (on terminal Osx at least)
Green Unicorn Console must be green
Thank you.
![Capture d e cran 2012-12-14 a 08 33 42](https://f.cloud.github.com/assets/240125/12771/9a462006-45c0-11e2-866b-b5f9fd5d02e8.png)
